### PR TITLE
feat: add check-for-updates page (Play / F-Droid / GitHub)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity android:name=".pages.FeedbackPageActivity" />
         <activity android:name=".pages.FunctionTestPageActivity" />
         <activity android:name=".pages.NotificationLogPageActivity" />
+        <activity android:name=".pages.CheckUpdatePageActivity" />
         <activity android:name=".pages.AboutThisPageActivity" />
         <activity android:name=".pages.FilterListActivity" />
         <activity android:name=".pages.AppInfoPageActivity" />

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
@@ -1,0 +1,75 @@
+package com.symeonchen.wakeupscreen.compose
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.symeonchen.wakeupscreen.R
+import com.symeonchen.wakeupscreen.compose.components.ComposeToolbar
+import com.symeonchen.wakeupscreen.compose.components.SettingRow
+
+@Composable
+fun CheckUpdateScreen(
+    onBack: () -> Unit,
+    onPlayStoreClick: () -> Unit,
+    onFDroidClick: () -> Unit,
+    onGitHubClick: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        ComposeToolbar(
+            title = stringResource(R.string.check_update),
+            onBack = onBack,
+        )
+
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.check_update_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
+            )
+
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surface,
+                tonalElevation = 0.dp,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column {
+                    SettingRow(
+                        title = stringResource(R.string.update_via_play),
+                        subtitle = stringResource(R.string.update_via_play_subtitle),
+                        onClick = onPlayStoreClick,
+                    )
+                    FlatDivider()
+                    SettingRow(
+                        title = stringResource(R.string.update_via_fdroid),
+                        subtitle = stringResource(R.string.update_via_fdroid_subtitle),
+                        onClick = onFDroidClick,
+                    )
+                    FlatDivider()
+                    SettingRow(
+                        title = stringResource(R.string.update_via_github),
+                        subtitle = stringResource(R.string.update_via_github_subtitle),
+                        onClick = onGitHubClick,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FlatDivider() {
+    HorizontalDivider(
+        modifier = Modifier.padding(horizontal = 20.dp),
+        thickness = 0.5.dp,
+        color = MaterialTheme.colorScheme.outline,
+    )
+}

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.symeonchen.wakeupscreen.BuildConfig
 import com.symeonchen.wakeupscreen.R
 import com.symeonchen.wakeupscreen.compose.components.ComposeToolbar
 import com.symeonchen.wakeupscreen.compose.components.SettingRow
@@ -29,10 +30,16 @@ fun CheckUpdateScreen(
 
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
+                text = stringResource(R.string.current_version, BuildConfig.VERSION_NAME),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp),
+            )
+            Text(
                 text = stringResource(R.string.check_update_hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
+                modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 8.dp),
             )
 
             Surface(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
@@ -48,6 +48,7 @@ fun SettingScreen(
     onAddressClick: () -> Unit,
     onFeedbackClick: () -> Unit,
     onGiveStarClick: () -> Unit,
+    onCheckUpdateClick: () -> Unit,
 ) {
     var appInfoExpanded by remember { mutableStateOf(false) }
 
@@ -205,6 +206,12 @@ fun SettingScreen(
                     title = stringResource(R.string.feedback),
                     subtitle = stringResource(R.string.feedback_subtitle),
                     onClick = onFeedbackClick,
+                )
+                FlatDivider()
+                SettingRow(
+                    title = stringResource(R.string.check_update),
+                    subtitle = stringResource(R.string.check_update_subtitle),
+                    onClick = onCheckUpdateClick,
                 )
                 FlatDivider()
                 SettingRow(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/pages/CheckUpdatePageActivity.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/pages/CheckUpdatePageActivity.kt
@@ -1,0 +1,26 @@
+package com.symeonchen.wakeupscreen.pages
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import com.symeonchen.wakeupscreen.ScBaseActivity
+import com.symeonchen.wakeupscreen.compose.CheckUpdateScreen
+import com.symeonchen.wakeupscreen.compose.theme.WakeUpScreenTheme
+import com.symeonchen.wakeupscreen.utils.UpdateChannelTools
+
+class CheckUpdatePageActivity : ScBaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            WakeUpScreenTheme {
+                CheckUpdateScreen(
+                    onBack = { finish() },
+                    onPlayStoreClick = { UpdateChannelTools.openPlayStore(this) },
+                    onFDroidClick = { UpdateChannelTools.openFDroid(this) },
+                    onGitHubClick = { UpdateChannelTools.openGitHubReleases(this) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/symeonchen/wakeupscreen/pages/ScSettingFragment.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/pages/ScSettingFragment.kt
@@ -76,6 +76,7 @@ class ScSettingFragment : ScBaseFragment() {
                     },
                     onFeedbackClick = { context?.quickStartActivity<FeedbackPageActivity>() },
                     onGiveStarClick = { PlayStoreTools.openPlayStoreWithUrl(context) },
+                    onCheckUpdateClick = { context?.quickStartActivity<CheckUpdatePageActivity>() },
                 )
 
                 // Language dialog

--- a/app/src/main/java/com/symeonchen/wakeupscreen/utils/UpdateChannelTools.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/utils/UpdateChannelTools.kt
@@ -1,0 +1,60 @@
+package com.symeonchen.wakeupscreen.utils
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+
+/**
+ * Opens an external app or web page so the user can check for / install
+ * updates. Everything here is an outbound [Intent] — the app never performs
+ * any network request itself, so no INTERNET permission is required.
+ */
+object UpdateChannelTools {
+
+    private const val FDROID_PACKAGE = "org.fdroid.fdroid"
+    private const val PLAY_STORE_PACKAGE = "com.android.vending"
+    private const val GITHUB_RELEASES_URL =
+        "https://github.com/riko2chen/WakeUpScreen/releases/latest"
+
+    /** Open the app's Google Play listing, falling back to the browser. */
+    fun openPlayStore(context: Context?) {
+        context ?: return
+        val webUrl = "https://play.google.com/store/apps/details?id=${context.packageName}"
+        try {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(webUrl)).setPackage(PLAY_STORE_PACKAGE)
+            )
+        } catch (_: ActivityNotFoundException) {
+            openInBrowser(context, webUrl)
+        }
+    }
+
+    /** Open the app's F-Droid page, preferring the F-Droid client app. */
+    fun openFDroid(context: Context?) {
+        context ?: return
+        val webUrl = "https://f-droid.org/packages/${context.packageName}/"
+        try {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(webUrl)).setPackage(FDROID_PACKAGE)
+            )
+        } catch (_: ActivityNotFoundException) {
+            openInBrowser(context, webUrl)
+        }
+    }
+
+    /** Open the GitHub "latest release" page in the browser. */
+    fun openGitHubReleases(context: Context?) {
+        openInBrowser(context, GITHUB_RELEASES_URL)
+    }
+
+    private fun openInBrowser(context: Context?, url: String) {
+        context ?: return
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -149,4 +149,13 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">Xiaohongshu</string>
 
+    <string name="check_update">Check for updates</string>
+    <string name="check_update_subtitle">Check via Play, F-Droid or GitHub</string>
+    <string name="check_update_hint">These options open an external app or page to check for updates. The app itself never connects to the internet.</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">Open the Play Store app page</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">Open the F-Droid page (version may be slightly behind)</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">Open the latest release page</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -149,6 +149,7 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">Xiaohongshu</string>
 
+    <string name="current_version">Current version: %1$s</string>
     <string name="check_update">Check for updates</string>
     <string name="check_update_subtitle">Check via Play, F-Droid or GitHub</string>
     <string name="check_update_hint">These options open an external app or page to check for updates. The app itself never connects to the internet.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -149,6 +149,7 @@
     <string name="language_th">Tailandese</string>
     <string name="language_zh_tw">Cinese Tradizionale</string>
 
+    <string name="current_version">Versione attuale: %1$s</string>
     <string name="check_update">Controlla aggiornamenti</string>
     <string name="check_update_subtitle">Controlla tramite Play, F-Droid o GitHub</string>
     <string name="check_update_hint">Queste opzioni aprono un\'app o una pagina esterna per controllare gli aggiornamenti. L\'app stessa non si connette mai a internet.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -149,4 +149,13 @@
     <string name="language_th">Tailandese</string>
     <string name="language_zh_tw">Cinese Tradizionale</string>
 
+    <string name="check_update">Controlla aggiornamenti</string>
+    <string name="check_update_subtitle">Controlla tramite Play, F-Droid o GitHub</string>
+    <string name="check_update_hint">Queste opzioni aprono un\'app o una pagina esterna per controllare gli aggiornamenti. L\'app stessa non si connette mai a internet.</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">Apri la pagina dell\'app su Play Store</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">Apri la pagina F-Droid (la versione potrebbe essere leggermente indietro)</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">Apri la pagina dell\'ultima release</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -136,6 +136,7 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小紅書</string>
 
+    <string name="current_version">現在のバージョン: %1$s</string>
     <string name="check_update">アップデートを確認</string>
     <string name="check_update_subtitle">Play・F-Droid・GitHub で確認</string>
     <string name="check_update_hint">以下のオプションは外部アプリやページを開いて更新を確認します。アプリ自体はインターネットに接続しません。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -136,4 +136,13 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小紅書</string>
 
+    <string name="check_update">アップデートを確認</string>
+    <string name="check_update_subtitle">Play・F-Droid・GitHub で確認</string>
+    <string name="check_update_hint">以下のオプションは外部アプリやページを開いて更新を確認します。アプリ自体はインターネットに接続しません。</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">Play ストアのアプリページを開く</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">F-Droid のページを開く（バージョンが少し遅れる場合があります）</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">最新リリースページを開く</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -136,6 +136,7 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">샤오홍슈</string>
 
+    <string name="current_version">현재 버전: %1$s</string>
     <string name="check_update">업데이트 확인</string>
     <string name="check_update_subtitle">Play, F-Droid 또는 GitHub로 확인</string>
     <string name="check_update_hint">아래 옵션은 외부 앱이나 페이지를 열어 업데이트를 확인합니다. 앱 자체는 인터넷에 연결하지 않습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -136,4 +136,13 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">샤오홍슈</string>
 
+    <string name="check_update">업데이트 확인</string>
+    <string name="check_update_subtitle">Play, F-Droid 또는 GitHub로 확인</string>
+    <string name="check_update_hint">아래 옵션은 외부 앱이나 페이지를 열어 업데이트를 확인합니다. 앱 자체는 인터넷에 연결하지 않습니다.</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">Play 스토어 앱 페이지 열기</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">F-Droid 페이지 열기 (버전이 다소 늦을 수 있음)</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">최신 릴리스 페이지 열기</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -136,6 +136,7 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">เสี่ยวหงซู</string>
 
+    <string name="current_version">เวอร์ชันปัจจุบัน: %1$s</string>
     <string name="check_update">ตรวจสอบการอัปเดต</string>
     <string name="check_update_subtitle">ตรวจสอบผ่าน Play, F-Droid หรือ GitHub</string>
     <string name="check_update_hint">ตัวเลือกเหล่านี้จะเปิดแอปหรือหน้าเว็บภายนอกเพื่อตรวจสอบการอัปเดต ตัวแอปเองไม่เชื่อมต่ออินเทอร์เน็ต</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -136,4 +136,13 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">เสี่ยวหงซู</string>
 
+    <string name="check_update">ตรวจสอบการอัปเดต</string>
+    <string name="check_update_subtitle">ตรวจสอบผ่าน Play, F-Droid หรือ GitHub</string>
+    <string name="check_update_hint">ตัวเลือกเหล่านี้จะเปิดแอปหรือหน้าเว็บภายนอกเพื่อตรวจสอบการอัปเดต ตัวแอปเองไม่เชื่อมต่ออินเทอร์เน็ต</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">เปิดหน้าแอปใน Play Store</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">เปิดหน้า F-Droid (เวอร์ชันอาจช้ากว่าเล็กน้อย)</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">เปิดหน้ารีลีสล่าสุด</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,6 +136,7 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小紅書</string>
 
+    <string name="current_version">目前版本：%1$s</string>
     <string name="check_update">檢查更新</string>
     <string name="check_update_subtitle">透過 Play、F-Droid 或 GitHub 檢查</string>
     <string name="check_update_hint">以下選項會跳轉到外部應用程式或網頁來檢查更新，App 本身不會連網。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,4 +136,13 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小紅書</string>
 
+    <string name="check_update">檢查更新</string>
+    <string name="check_update_subtitle">透過 Play、F-Droid 或 GitHub 檢查</string>
+    <string name="check_update_hint">以下選項會跳轉到外部應用程式或網頁來檢查更新，App 本身不會連網。</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">開啟 Play 商店應用頁</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">開啟 F-Droid 頁面（版本可能稍有延遲）</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">開啟最新發布頁面</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -137,6 +137,7 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小红书</string>
 
+    <string name="current_version">当前版本：%1$s</string>
     <string name="check_update">检查更新</string>
     <string name="check_update_subtitle">通过 Play、F-Droid 或 GitHub 检查</string>
     <string name="check_update_hint">以下选项会跳转到外部应用或网页来检查更新，App 本身不会联网。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -137,4 +137,13 @@
     <string name="feedback_contact_x">X（Twitter）</string>
     <string name="feedback_contact_xiaohongshu">小红书</string>
 
+    <string name="check_update">检查更新</string>
+    <string name="check_update_subtitle">通过 Play、F-Droid 或 GitHub 检查</string>
+    <string name="check_update_hint">以下选项会跳转到外部应用或网页来检查更新，App 本身不会联网。</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">打开 Play 商店应用页</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">打开 F-Droid 页面（版本可能稍有延迟）</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">打开最新发布页面</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">Xiaohongshu</string>
 
+    <string name="current_version">Current version: %1$s</string>
     <string name="check_update">Check for updates</string>
     <string name="check_update_subtitle">Check via Play, F-Droid or GitHub</string>
     <string name="check_update_hint">These options open an external app or page to check for updates. The app itself never connects to the internet.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,4 +150,13 @@
     <string name="feedback_contact_x">X (Twitter)</string>
     <string name="feedback_contact_xiaohongshu">Xiaohongshu</string>
 
+    <string name="check_update">Check for updates</string>
+    <string name="check_update_subtitle">Check via Play, F-Droid or GitHub</string>
+    <string name="check_update_hint">These options open an external app or page to check for updates. The app itself never connects to the internet.</string>
+    <string name="update_via_play">Google Play</string>
+    <string name="update_via_play_subtitle">Open the Play Store app page</string>
+    <string name="update_via_fdroid">F-Droid</string>
+    <string name="update_via_fdroid_subtitle">Open the F-Droid page (version may be slightly behind)</string>
+    <string name="update_via_github">GitHub Releases</string>
+    <string name="update_via_github_subtitle">Open the latest release page</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds a **Check for updates** entry in Settings → About. Tapping it opens a secondary page offering three update channels:

- **Google Play** — opens the Play Store app listing
- **F-Droid** — opens the F-Droid client / package page
- **GitHub Releases** — opens the latest release page

## Design notes

- **No INTERNET permission.** Every channel is an outbound `ACTION_VIEW` intent (with a browser fallback); the app never makes a network request itself. The privacy-friendly, no-network posture is preserved.
- All three target URLs were verified to exist before wiring them up (Play `og:title` resolves, F-Droid package page exists, GitHub `releases/latest` → `v3.0.4`).
- New page follows the existing Compose pattern: `CheckUpdatePageActivity` hosts `CheckUpdateScreen` (`ComposeToolbar` + `SettingRow` cards), launched via `quickStartActivity`.
- Channel logic lives in `UpdateChannelTools` (mirrors the existing `PlayStoreTools` fallback pattern).

## Localization

Copy added to **all** supported languages: default/en, zh, zh-rTW, ja, ko, it, th. The F-Droid subtitle notes its version may lag slightly (F-Droid rebuilds from source on its own schedule).

## Notes / limitations

- This is "open the place where you can update", not an in-app "you're up to date / new version available" check — that's the trade-off for staying offline.
- No version bump; merging will not trigger a release.

## Test plan
- `./gradlew :app:assembleDebug` passes (Kotlin + resource merge across all locales).