### PR TITLE
fix: safe-area (window insets) across the whole app

### DIFF
--- a/app/src/main/java/com/symeonchen/wakeupscreen/MainActivity.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.symeonchen.wakeupscreen
 
 import android.os.Bundle
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
@@ -24,6 +27,14 @@ class MainActivity : ScBaseActivity() {
     }
 
     private fun initView() {
+        // Edge-to-edge is enforced on Android 15+, so keep the bottom nav above
+        // the gesture / navigation bar instead of being hidden behind it.
+        ViewCompat.setOnApplyWindowInsetsListener(binding.bnvMain) { view, insets ->
+            val bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+            view.updatePadding(bottom = bottom)
+            insets
+        }
+
         binding.vpMain.adapter = MainViewPagerAdapter(this, fragmentList)
 
         binding.vpMain.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AboutScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AboutScreen.kt
@@ -17,7 +17,7 @@ fun AboutScreen(
     onBack: () -> Unit,
     onAppIntroduceClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.about),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
@@ -42,7 +42,7 @@ fun AdvanceSettingScreen(
     sleepDetailSubtitle: String,
     onSleepDetailClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.advanced_setting),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AppInfoScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AppInfoScreen.kt
@@ -26,7 +26,7 @@ import com.symeonchen.wakeupscreen.compose.components.ComposeToolbar
 fun AppInfoScreen(
     onBack: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.app_name),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
@@ -22,7 +22,7 @@ fun CheckUpdateScreen(
     onFDroidClick: () -> Unit,
     onGitHubClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.check_update),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/FeedbackScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/FeedbackScreen.kt
@@ -22,7 +22,7 @@ fun FeedbackScreen(
     onContactX: () -> Unit,
     onContactXiaohongshu: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.feedback),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/FunctionTestScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/FunctionTestScreen.kt
@@ -19,7 +19,7 @@ fun FunctionTestScreen(
     onWakeTestClick: () -> Unit,
     onViewLogsClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.function_test),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/NotificationLogScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/NotificationLogScreen.kt
@@ -29,7 +29,7 @@ fun NotificationLogScreen(
 ) {
     var selectedEntry by remember { mutableStateOf<NotificationLogEntry?>(null) }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.view_logs),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
@@ -68,9 +68,10 @@ fun SettingScreen(
                         end = Offset(400f, 300f),
                     )
                 )
-                // Gradient bleeds under the status bar; title stays below it.
+                // Gradient bleeds under the status bar; the title sits in a
+                // 64dp band below it (so the total header isn't over-inflated).
                 .statusBarsPadding()
-                .height(100.dp),
+                .height(64.dp),
             contentAlignment = Alignment.BottomCenter,
         ) {
             Text(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/SettingScreen.kt
@@ -61,14 +61,16 @@ fun SettingScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(100.dp)
                 .background(
                     Brush.linearGradient(
                         listOf(GradientStart, GradientMid, GradientEnd),
                         start = Offset(0f, 0f),
                         end = Offset(400f, 300f),
                     )
-                ),
+                )
+                // Gradient bleeds under the status bar; title stays below it.
+                .statusBarsPadding()
+                .height(100.dp),
             contentAlignment = Alignment.BottomCenter,
         ) {
             Text(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/SleepTimeScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/SleepTimeScreen.kt
@@ -22,7 +22,7 @@ fun SleepTimeScreen(
     onBeginHourChange: (Int) -> Unit,
     onEndHourChange: (Int) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.sleep_time),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/WakeUpTimeScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/WakeUpTimeScreen.kt
@@ -33,7 +33,7 @@ fun WakeUpTimeScreen(
     onInputChange: (String) -> Unit,
     onPresetClick: (Long) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.time_of_wake_up_screen),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/components/ComposeToolbar.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/components/ComposeToolbar.kt
@@ -31,14 +31,18 @@ fun ComposeToolbar(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp)
             .background(
                 Brush.linearGradient(
                     listOf(GradientStart, GradientMid, GradientEnd),
                     start = Offset(0f, 0f),
                     end = Offset(600f, 0f),
                 )
-            ),
+            )
+            // Let the gradient bleed under the status bar, but keep the back
+            // button and title below it so they aren't hidden by the camera
+            // cutout / unreachable behind the status bar (edge-to-edge).
+            .statusBarsPadding()
+            .height(56.dp),
     ) {
         // Back button
         Icon(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/components/HeroSection.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/components/HeroSection.kt
@@ -48,7 +48,9 @@ fun HeroSection(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(horizontal = 32.dp),
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 32.dp),
         ) {
             // Decorative app label
             Text(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/pages/FilterListActivity.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/pages/FilterListActivity.kt
@@ -7,6 +7,10 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -94,6 +98,24 @@ class FilterListActivity : ScBaseActivity() {
             resources.getString(R.string.white_list_hints)
         }
         binding.tvLogHeadHint.text = hints
+
+        applyWindowInsets()
+    }
+
+    /**
+     * Edge-to-edge is enforced on Android 15+. Keep the gradient header below
+     * the status bar / camera cutout, and the list above the gesture bar.
+     */
+    private fun applyWindowInsets() {
+        val baseHeaderHeight = binding.llHeader.layoutParams.height
+        val baseListPaddingBottom = binding.rvAppList.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.llHeader.updateLayoutParams { height = baseHeaderHeight + bars.top }
+            binding.llHeader.updatePadding(top = bars.top)
+            binding.rvAppList.updatePadding(bottom = baseListPaddingBottom + bars.bottom)
+            insets
+        }
     }
 
     private fun setListener() {


### PR DESCRIPTION
Consolidated safe-area / window-insets fix for edge-to-edge (Android 15+, `targetSdk 35`). Previously content drew behind the status bar / camera cutout and the gesture bar: secondary-page back buttons were unreachable, some titles were hidden, and long lists were clipped at the bottom.

## Top insets
- **`ComposeToolbar`** (all secondary pages), **`SettingScreen` header**, **`HeroSection`** (home): gradient still bleeds under the status bar, but content is pushed below it via `statusBarsPadding()`.
- **`MainActivity`**: bottom navigation padded by the navigation-bar inset so it isn't hidden behind the gesture bar.

## Bottom insets (secondary pages)
- All 9 Compose secondary screens (About, Advanced Setting, App Info, Check Update, Feedback, Function Test, Notification Log, Sleep Time, Wake-up Time): `navigationBarsPadding()` on the root so the last content/list item clears the gesture bar.
- **`FilterListActivity`** (XML/RecyclerView): window-insets listener grows the gradient header by the status-bar inset and pads the list bottom by the navigation-bar inset. No XML change.

Top (`statusBarsPadding`) and bottom (`navigationBarsPadding`) consume different inset types, so they compose without double-padding.

## Test plan
- `./gradlew :app:assembleDebug` passes.
- Manual on an Android 15/16 emulator (incl. a camera-cutout device, gesture nav): back buttons tappable, titles clear the status bar, bottom nav and long lists clear the gesture bar.