### PR TITLE
fix: keep secondary-page content above the navigation / gesture bar

### DIFF
--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AboutScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AboutScreen.kt
@@ -17,7 +17,7 @@ fun AboutScreen(
     onBack: () -> Unit,
     onAppIntroduceClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.about),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
@@ -42,7 +42,7 @@ fun AdvanceSettingScreen(
     sleepDetailSubtitle: String,
     onSleepDetailClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.advanced_setting),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AppInfoScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AppInfoScreen.kt
@@ -26,7 +26,7 @@ import com.symeonchen.wakeupscreen.compose.components.ComposeToolbar
 fun AppInfoScreen(
     onBack: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.app_name),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/CheckUpdateScreen.kt
@@ -22,7 +22,7 @@ fun CheckUpdateScreen(
     onFDroidClick: () -> Unit,
     onGitHubClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.check_update),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/FeedbackScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/FeedbackScreen.kt
@@ -22,7 +22,7 @@ fun FeedbackScreen(
     onContactX: () -> Unit,
     onContactXiaohongshu: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.feedback),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/FunctionTestScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/FunctionTestScreen.kt
@@ -19,7 +19,7 @@ fun FunctionTestScreen(
     onWakeTestClick: () -> Unit,
     onViewLogsClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.function_test),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/NotificationLogScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/NotificationLogScreen.kt
@@ -29,7 +29,7 @@ fun NotificationLogScreen(
 ) {
     var selectedEntry by remember { mutableStateOf<NotificationLogEntry?>(null) }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.view_logs),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/SleepTimeScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/SleepTimeScreen.kt
@@ -22,7 +22,7 @@ fun SleepTimeScreen(
     onBeginHourChange: (Int) -> Unit,
     onEndHourChange: (Int) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.sleep_time),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/WakeUpTimeScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/WakeUpTimeScreen.kt
@@ -33,7 +33,7 @@ fun WakeUpTimeScreen(
     onInputChange: (String) -> Unit,
     onPresetClick: (Long) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
         ComposeToolbar(
             title = stringResource(R.string.time_of_wake_up_screen),
             onBack = onBack,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/pages/FilterListActivity.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/pages/FilterListActivity.kt
@@ -7,6 +7,10 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -94,6 +98,24 @@ class FilterListActivity : ScBaseActivity() {
             resources.getString(R.string.white_list_hints)
         }
         binding.tvLogHeadHint.text = hints
+
+        applyWindowInsets()
+    }
+
+    /**
+     * Edge-to-edge is enforced on Android 15+. Keep the gradient header below
+     * the status bar / camera cutout, and the list above the gesture bar.
+     */
+    private fun applyWindowInsets() {
+        val baseHeaderHeight = binding.llHeader.layoutParams.height
+        val baseListPaddingBottom = binding.rvAppList.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.llHeader.updateLayoutParams { height = baseHeaderHeight + bars.top }
+            binding.llHeader.updatePadding(top = bars.top)
+            binding.rvAppList.updatePadding(bottom = baseListPaddingBottom + bars.bottom)
+            insets
+        }
     }
 
     private fun setListener() {


### PR DESCRIPTION
## Problem

Follow-up to the top safe-area fix. Under edge-to-edge (Android 15+, `targetSdk 35`), the **bottom** of full-screen secondary pages drew behind the gesture / navigation bar — long lists (e.g. notification log, white/black list) had their last items obscured.

## Fix

- **Compose secondary screens** — added `navigationBarsPadding()` to the root `Column` of all 9 screens: About, Advanced Setting, App Info, Check Update, Feedback, Function Test, Notification Log, Sleep Time, Wake-up Time. This consumes only the bottom navigation-bar inset, so it composes cleanly with the top `statusBarsPadding()` on `ComposeToolbar` (different inset types).
- **`FilterListActivity`** (XML / RecyclerView) — added a `setOnApplyWindowInsetsListener`: the gradient header grows by the status-bar inset (so it clears the cutout) and the list gets bottom padding equal to the navigation-bar inset (so the last item clears the gesture bar). No XML layout change required.

## Notes

- Independent of the top-bar PR — these touch different views / insets, so no conflict.
- Home & Settings are not full-screen (they sit above the bottom nav, which already handles its own inset), so they're intentionally not changed here.

## Test plan
- `./gradlew :app:assembleDebug` passes.
- Manual: on an Android 15/16 emulator with gesture nav, open each secondary page and the white/black list — last list item is fully visible above the gesture bar; FilterList header clears the status bar.