### PR TITLE
chore: release 3.0.6 — remove FOREGROUND_SERVICE_SPECIAL_USE

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
@@ -40,14 +38,10 @@
         <service
             android:name=".services.ScNotificationListenerService"
             android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
-            android:foregroundServiceType="specialUse"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="Wake up screen when notification received" />
         </service>
 
         <receiver android:name=".receiver.PackageReplacedReceiver"

--- a/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/compose/AdvanceSettingScreen.kt
@@ -26,9 +26,6 @@ fun AdvanceSettingScreen(
     radicalOngoingChecked: Boolean,
     radicalOngoingSubtitle: String,
     onRadicalOngoingToggle: () -> Unit,
-    persistentChecked: Boolean,
-    persistentSubtitle: String,
-    onPersistentToggle: () -> Unit,
     dndChecked: Boolean,
     onDndToggle: () -> Unit,
     chargingOnlyChecked: Boolean,
@@ -79,13 +76,6 @@ fun AdvanceSettingScreen(
                         subtitle = radicalOngoingSubtitle,
                         checked = radicalOngoingChecked,
                         onCheckedChange = onRadicalOngoingToggle,
-                    )
-                    FlatDivider()
-                    SettingSwitchRow(
-                        title = stringResource(R.string.show_notification_when_service_start),
-                        subtitle = persistentSubtitle,
-                        checked = persistentChecked,
-                        onCheckedChange = onPersistentToggle,
                     )
                     FlatDivider()
                     SettingSwitchRow(

--- a/app/src/main/java/com/symeonchen/wakeupscreen/data/ScConstant.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/data/ScConstant.kt
@@ -24,7 +24,6 @@ object ScConstant {
     const val SLEEP_MODE_TIME_END = "sleep_mode_time_end"
     const val DND_DETECT_SWITCH = "dnd_detect_switch"
     const val LAST_IN_APP_REVIEW_TIMESTAMP = "last_in_app_review_timestamp"
-    const val PERSISTENT_NOTIFICATION = "persistent_notification"
     const val CHARGING_ONLY_SWITCH = "charging_only_switch"
 
     const val DEFAULT_SWITCH_OF_APP: Boolean = true
@@ -47,7 +46,6 @@ object ScConstant {
     const val DEFAULT_SLEEP_MODE_TIME_END_HOUR = 4
     const val DEFAULT_DND_DETECT_SWITCH = true
     const val DEFAULT_LAST_IN_APP_REVIEW_TIMESTAMP = "0"
-    const val DEFAULT_PERSISTENT_NOTIFICATION = false
     const val DEFAULT_CHARGING_ONLY_SWITCH = false
 
 

--- a/app/src/main/java/com/symeonchen/wakeupscreen/model/SettingViewModel.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/model/SettingViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import com.symeonchen.wakeupscreen.ScLiveData
 import com.symeonchen.wakeupscreen.data.CurrentMode
 import com.symeonchen.wakeupscreen.data.LanguageInfo
-import com.symeonchen.wakeupscreen.services.ScNotificationListenerService
 import com.symeonchen.wakeupscreen.utils.DataInjection
 
 /**
@@ -83,11 +82,6 @@ class SettingViewModel : ViewModel() {
             setValue(DataInjection.chargingOnlySwitch)
         }
 
-    var persistentSwitch: ScLiveData<Boolean> = ScLiveData<Boolean>()
-        .apply {
-            setValue(DataInjection.persistentNotification)
-        }
-
     init {
 
         switchOfApp.listener = object : ScLiveData.OnLiveDataValueInput<Boolean> {
@@ -163,13 +157,6 @@ class SettingViewModel : ViewModel() {
         chargingOnlySwitch.listener = object : ScLiveData.OnLiveDataValueInput<Boolean> {
             override fun onValueInput(value: Boolean) {
                 DataInjection.chargingOnlySwitch = value
-            }
-        }
-
-        persistentSwitch.listener = object : ScLiveData.OnLiveDataValueInput<Boolean> {
-            override fun onValueInput(value: Boolean) {
-                DataInjection.persistentNotification = value
-                ScNotificationListenerService.instance?.updateForegroundState()
             }
         }
     }

--- a/app/src/main/java/com/symeonchen/wakeupscreen/pages/AdvanceSettingPageActivity.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/pages/AdvanceSettingPageActivity.kt
@@ -29,7 +29,6 @@ class AdvanceSettingPageActivity : ScBaseActivity() {
                 val proximity by settingModel.switchOfProximity.observeAsState(false)
                 val ongoing by settingModel.ongoingOptimize.observeAsState(false)
                 val radicalOngoing by settingModel.radicalOngoingOptimize.observeAsState(false)
-                val persistent by settingModel.persistentSwitch.observeAsState(false)
                 val dnd by settingModel.dndDetectBoolean.observeAsState(false)
                 val chargingOnly by settingModel.chargingOnlySwitch.observeAsState(false)
                 val sleep by settingModel.sleepModeBoolean.observeAsState(false)
@@ -56,9 +55,6 @@ class AdvanceSettingPageActivity : ScBaseActivity() {
                     radicalOngoingChecked = radicalOngoing,
                     radicalOngoingSubtitle = statusText(radicalOngoing),
                     onRadicalOngoingToggle = { settingModel.radicalOngoingOptimize.postValue(!radicalOngoing) },
-                    persistentChecked = persistent,
-                    persistentSubtitle = statusText(persistent),
-                    onPersistentToggle = { settingModel.persistentSwitch.postValue(!persistent) },
                     dndChecked = dnd,
                     onDndToggle = { settingModel.dndDetectBoolean.postValue(!dnd) },
                     chargingOnlyChecked = chargingOnly,

--- a/app/src/main/java/com/symeonchen/wakeupscreen/services/ScNotificationListenerService.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/services/ScNotificationListenerService.kt
@@ -2,13 +2,11 @@ package com.symeonchen.wakeupscreen.services
 
 import android.app.NotificationChannel
 import android.content.ComponentName
-import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.PowerManager
 import android.service.notification.NotificationListenerService
 import android.service.notification.NotificationListenerService.Ranking
 import android.service.notification.StatusBarNotification
-import com.symeonchen.wakeupscreen.R
 import com.symeonchen.wakeupscreen.services.notification.BlockReason
 import com.symeonchen.wakeupscreen.services.notification.ConditionParam
 import com.symeonchen.wakeupscreen.services.notification.ListenerManager
@@ -18,7 +16,6 @@ import com.symeonchen.wakeupscreen.data.NotificationLogStore
 import com.symeonchen.wakeupscreen.services.notification.ConditionState
 import com.symeonchen.wakeupscreen.services.notification.conditions.*
 import com.symeonchen.wakeupscreen.utils.DataInjection
-import com.symeonchen.wakeupscreen.utils.NotificationUtils
 import kotlinx.coroutines.*
 
 /**
@@ -36,31 +33,12 @@ class ScNotificationListenerService : NotificationListenerService() {
     override fun onCreate() {
         super.onCreate()
         instance = this
-        updateForegroundState()
     }
 
     override fun onDestroy() {
         super.onDestroy()
         instance = null
-        stopForeground(STOP_FOREGROUND_REMOVE)
     }
-
-    fun updateForegroundState() {
-        if (!DataInjection.persistentNotification) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            return
-        }
-        val notificationBuilder = NotificationUtils(this).getNotification(
-            resources.getString(R.string.app_name),
-            resources.getString(R.string.running_to_prevent_kill_app)
-        )
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(1, notificationBuilder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
-        } else {
-            startForeground(1, notificationBuilder.build())
-        }
-    }
-
 
     init {
         ListenerManager.register(PocketModeCondition())

--- a/app/src/main/java/com/symeonchen/wakeupscreen/utils/DataInjection.kt
+++ b/app/src/main/java/com/symeonchen/wakeupscreen/utils/DataInjection.kt
@@ -21,7 +21,6 @@ import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_LANGUAGE_SELECTED
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_LAST_IN_APP_REVIEW_TIMESTAMP
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_ONGOING_STATUS_DETECT
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_PERMISSION_OF_SEND_NOTIFICATION
-import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_PERSISTENT_NOTIFICATION
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_RADICAL_ONGOING_DETECT
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_RADICAL_ONGOING_NOTIFICATION_SWITCH
 import com.symeonchen.wakeupscreen.data.ScConstant.DEFAULT_SLEEP_MODE_BOOLEAN
@@ -36,7 +35,6 @@ import com.symeonchen.wakeupscreen.data.ScConstant.DND_DETECT_SWITCH
 import com.symeonchen.wakeupscreen.data.ScConstant.LANGUAGE_SELECTED
 import com.symeonchen.wakeupscreen.data.ScConstant.LAST_IN_APP_REVIEW_TIMESTAMP
 import com.symeonchen.wakeupscreen.data.ScConstant.ONGOING_STATUS_DETECT
-import com.symeonchen.wakeupscreen.data.ScConstant.PERSISTENT_NOTIFICATION
 import com.symeonchen.wakeupscreen.data.ScConstant.PROXIMITY_STATUS
 import com.symeonchen.wakeupscreen.data.ScConstant.PROXIMITY_SWITCH
 import com.symeonchen.wakeupscreen.data.ScConstant.RADICAL_ONGOING_DETECT
@@ -273,14 +271,4 @@ object DataInjection {
             MMKV.defaultMMKV()?.putBoolean(CHARGING_ONLY_SWITCH, value)
         }
 
-    var persistentNotification: Boolean
-        get() {
-            return MMKV.defaultMMKV()?.getBoolean(
-                PERSISTENT_NOTIFICATION,
-                DEFAULT_PERSISTENT_NOTIFICATION
-            ) ?: DEFAULT_PERSISTENT_NOTIFICATION
-        }
-        set(value) {
-            MMKV.defaultMMKV()?.putBoolean(PERSISTENT_NOTIFICATION, value)
-        }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -103,8 +103,6 @@
     <string name="close_app_notice">This action will close Application, please reopen the APP after that.</string>
     <string name="include_system_app">Include system APP</string>
     <string name="radical_ongoing_detact">Radical Ongoing Detect (unstable)</string>
-    <string name="running_to_prevent_kill_app">Service is running</string>
-    <string name="show_notification_when_service_start">Show Notification After Service Start(It will take effect after the phone is restarted)</string>
     <string name="send_notification_permission">Permission to send notifications</string>
 
     <string name="function_test">Function Test</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -99,8 +99,6 @@
     <string name="close_app_notice">Questa azione chiuderà l\'Applicazione, quindi riaprire l\'APP successivamente.</string>
     <string name="include_system_app">Includi APP di sistema</string>
     <string name="radical_ongoing_detact">Detección continua radical (inestable)</string>
-    <string name="running_to_prevent_kill_app">Servizio in esecuzione</string>
-    <string name="show_notification_when_service_start">Mostra notifica dopo l\'inizio del servizio(Esso avrà effetto dopo che il telefono sarà riavviato)</string>
     <string name="send_notification_permission">Permesso di inviare notifiche</string>
 
     <string name="function_test">Test funzionale</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -90,8 +90,6 @@
     <string name="close_app_notice">この操作によりアプリが終了します。終了後にアプリを再度開いてください。</string>
     <string name="include_system_app">システムアプリを含む</string>
     <string name="radical_ongoing_detact">厳格な継続通知フィルタリング（実験的機能）</string>
-    <string name="running_to_prevent_kill_app">サービスは正常に動作中</string>
-    <string name="show_notification_when_service_start">サービス開始後に通知を表示（端末再起動後に有効）</string>
     <string name="send_notification_permission">通知送信の権限</string>
 
     <string name="function_test">機能テスト</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -90,8 +90,6 @@
     <string name="close_app_notice">이 작업으로 앱이 종료됩니다. 종료 후 앱을 다시 열어주세요.</string>
     <string name="include_system_app">시스템 앱 포함</string>
     <string name="radical_ongoing_detact">엄격한 지속 알림 필터링 (실험적 기능)</string>
-    <string name="running_to_prevent_kill_app">서비스가 정상적으로 실행 중</string>
-    <string name="show_notification_when_service_start">서비스 시작 후 알림 표시 (휴대폰 재시작 후 적용)</string>
     <string name="send_notification_permission">알림 전송 권한</string>
 
     <string name="function_test">기능 테스트</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -90,8 +90,6 @@
     <string name="close_app_notice">การกระทำนี้จะปิดแอป กรุณาเปิดแอปอีกครั้งหลังจากนั้น</string>
     <string name="include_system_app">รวมแอประบบ</string>
     <string name="radical_ongoing_detact">กรองการแจ้งเตือนต่อเนื่องแบบเข้มงวด (ทดลอง)</string>
-    <string name="running_to_prevent_kill_app">บริการกำลังทำงาน</string>
-    <string name="show_notification_when_service_start">แสดงการแจ้งเตือนหลังเริ่มบริการ (มีผลหลังรีสตาร์ทโทรศัพท์)</string>
     <string name="send_notification_permission">สิทธิ์ในการส่งการแจ้งเตือน</string>
 
     <string name="function_test">ทดสอบฟังก์ชัน</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -90,8 +90,6 @@
     <string name="close_app_notice">此操作將關閉應用程式，請在此之後重新開啟。</string>
     <string name="include_system_app">包含系統應用程式</string>
     <string name="radical_ongoing_detact">嚴格的持續通知過濾（實驗功能）</string>
-    <string name="running_to_prevent_kill_app">服務正常運行中</string>
-    <string name="show_notification_when_service_start">服務啟動後顯示通知（手機重新啟動後生效）</string>
     <string name="send_notification_permission">傳送通知的權限</string>
 
     <string name="function_test">功能測試</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -91,8 +91,6 @@
     <string name="close_app_notice">此操作将关闭应用，请在此之后重新打开它。</string>
     <string name="include_system_app">包括系统应用</string>
     <string name="radical_ongoing_detact">严格的持续通知过滤（实验功能）</string>
-    <string name="running_to_prevent_kill_app">服务正常运行中</string>
-    <string name="show_notification_when_service_start">服务启动后显示通知（手机重启后生效）</string>
     <string name="send_notification_permission">发送通知的权限</string>
 
     <string name="function_test">功能测试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,8 +104,6 @@
     <string name="close_app_notice">This action will close Application, please reopen the APP after that.</string>
     <string name="include_system_app">Include system APP</string>
     <string name="radical_ongoing_detact">Radical Ongoing Detect (unstable)</string>
-    <string name="running_to_prevent_kill_app">Service is running</string>
-    <string name="show_notification_when_service_start">Show Notification After Service Start(It will take effect after the phone is restarted)</string>
     <string name="send_notification_permission">Permission to send notifications</string>
 
     <string name="function_test">Function Test</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
-AppVersionCode=30500
-AppVersionName=3.0.5
+AppVersionCode=30600
+AppVersionName=3.0.6


### PR DESCRIPTION
## 背景

应用商店提示 `FOREGROUND_SERVICE_SPECIAL_USE` 属于需声明/审查的高风险权限。排查后发现它唯一的使用方是**可选的「常驻通知防杀」前台服务功能**（默认关闭）。核心唤醒功能走 `NotificationListenerService`，由系统自动绑定/重连，不需要前台服务，因此移除该功能即可彻底去掉权限。

## 改动

- **AndroidManifest.xml**：删除 `FOREGROUND_SERVICE` 与 `FOREGROUND_SERVICE_SPECIAL_USE` 权限、service 的 `foregroundServiceType="specialUse"` 及 `PROPERTY_SPECIAL_USE_FGS_SUBTYPE` 声明
- **ScNotificationListenerService.kt**：移除 `startForeground`/`updateForegroundState` 逻辑及无用 import
- **SettingViewModel / AdvanceSettingScreen / AdvanceSettingPageActivity**：移除「常驻通知」开关及其 UI
- **DataInjection / ScConstant**：删除 `persistentNotification` 存取与常量
- 8 个语言的 `strings.xml`：清理不再引用的文案
- **gradle.properties**：版本 `3.0.5 → 3.0.6`（`30500 → 30600`）

## 验证

- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL
- 检查新生成的 merged manifest，已无任何 foreground-service / special-use 权限

## 注意

靠常驻通知在激进杀后台机型（小米/华为等）上保活的用户，应用被系统回收概率会略升。已有 `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`，建议在引导中强化「关闭电池优化 / 加入白名单」作为替代。